### PR TITLE
RDKB-64590 Coverity issues in ccsp-psm component

### DIFF
--- a/source/Ssp/ssp_dbus.c
+++ b/source/Ssp/ssp_dbus.c
@@ -784,6 +784,7 @@ int  getParameterValues(
                                 AnscFreeMemory(pParameterValue->val->parameterName);
                                 AnscFreeMemory(pParameterValue->val);
                                 AnscFreeMemory(pParameterValue);
+                                pParameterValue = NULL;  // Set to NULL after freeing
                                 ret = CCSP_FAILURE;
                                 goto EXIT;
                             }
@@ -795,6 +796,7 @@ int  getParameterValues(
                             AnscFreeMemory(pParameterValue->val->parameterName);
                             AnscFreeMemory(pParameterValue->val);
                             AnscFreeMemory(pParameterValue);
+                            pParameterValue = NULL;  // Set to NULL after freeing
                         }
                     }
                     else
@@ -810,6 +812,7 @@ int  getParameterValues(
                 else
                 {
                     AnscFreeMemory(pParameterValue);
+                    pParameterValue = NULL;  // Set to NULL after freeing
                 }
             }
         }
@@ -852,6 +855,29 @@ int  getParameterValues(
     *param_val = val;
 
 EXIT:
+
+    /* FIX: CID: 70045 Resource_leak : cleanup any remaining nodes in list to avoid memory leak */
+        PSINGLE_LINK_ENTRY pSLinkEntry = NULL;
+        while ((pSLinkEntry = AnscSListPopEntry(&ParameterValueList)) != NULL)
+        {
+            pParameterValue = ACCESS_CONTAINER(pSLinkEntry, PARAMETER_VALUE, Linkage);
+
+            if (pParameterValue)
+            {
+                if (pParameterValue->val)
+                {
+                    if (pParameterValue->val->parameterName)
+                        AnscFreeMemory(pParameterValue->val->parameterName);
+
+                    if (pParameterValue->val->parameterValue)
+                        AnscFreeMemory(pParameterValue->val->parameterValue);
+
+                    AnscFreeMemory(pParameterValue->val);
+                }
+                AnscFreeMemory(pParameterValue);
+            }
+        }
+    
 
     if ( hSysRoot )
     {


### PR DESCRIPTION
Reason for change: Coverity high imapct issues in ccsp-psm
Test Procedure: not applicable
Risks: Low
Priority: P1